### PR TITLE
Allow customizable tables and search for multiple tags in Grafana

### DIFF
--- a/src/components/AlertsCard/AlertsCard.tsx
+++ b/src/components/AlertsCard/AlertsCard.tsx
@@ -52,30 +52,67 @@ const AlertStatusBadge = ({ alert }: { alert: GrafanaAlert }) => {
   );
 };
 
-export const AlertsTable = ({ alerts }: { alerts: GrafanaAlert[] }) => {
+export const AlertsTable = ({
+  alerts,
+  opts,
+}: {
+  alerts: GrafanaAlert[];
+  opts?: AlertsCardOpts;
+}) => {
   const columns: TableColumn<GrafanaAlert>[] = [
     {
+      title: 'id',
+      field: 'name',
+      hidden: true,
+      searchable: true,
+      render: (row: GrafanaAlert): string => row.name,
+    },
+    {
       title: 'Name',
-      cellStyle: {width: '90%'},
-      render: (row: GrafanaAlert): React.ReactNode => <Link href={`${row.url}?panelId=${row.panelId}&fullscreen&refresh=5s`} target="_blank" rel="noopener">{row.name}</Link>,
+      cellStyle: { width: '90%' },
+      render: (row: GrafanaAlert): React.ReactNode => (
+        <Link
+          href={`${row.url}?panelId=${row.panelId}&fullscreen&refresh=5s`}
+          target="_blank"
+          rel="noopener"
+        >
+          {row.name}
+        </Link>
+      ),
     },
     {
       title: 'State',
-      render: (row: GrafanaAlert): React.ReactNode => <AlertStatusBadge alert={row} />,
+      render: (row: GrafanaAlert): React.ReactNode => (
+        <AlertStatusBadge alert={row} />
+      ),
     },
   ];
 
   return (
     <Table
       title="Alerts"
-      options={{ paging: false, search: false, sorting: false, draggable: false, padding: 'dense' }}
+      options={{
+        paging: opts?.paged ?? false,
+        pageSize: opts?.pageSize ?? 5,
+        search: opts?.searchable ?? false,
+        emptyRowsWhenPaging: false,
+        sorting: false,
+        draggable: false,
+        padding: 'dense',
+      }}
       data={alerts}
       columns={columns}
     />
   );
 };
 
-const Alerts = ({ entity }: { entity: Entity }) => {
+const Alerts = ({
+  entity,
+  opts,
+}: {
+  entity: Entity;
+  opts?: AlertsCardOpts;
+}) => {
   const grafanaApi = useApi(grafanaApiRef);
   const { value, loading, error } = useAsync(async () => await grafanaApi.alertsByDashboardTag(tagSelectorFromEntity(entity)));
 
@@ -85,17 +122,21 @@ const Alerts = ({ entity }: { entity: Entity }) => {
     return <Alert severity="error">{error.message}</Alert>;
   }
 
-  return (
-    <AlertsTable alerts={value || []} />
-  );
+  return <AlertsTable alerts={value || []} opts={opts} />;
 };
 
-export const AlertsCard = () => {
+export type AlertsCardOpts = {
+  paged?: boolean;
+  searchable?: boolean;
+  pageSize?: number;
+};
+
+export const AlertsCard = (opts?: AlertsCardOpts) => {
   const { entity } = useEntity();
 
   return !isGrafanaAvailable(entity) ? (
     <MissingAnnotationEmptyState annotation={GRAFANA_ANNOTATION_TAG_SELECTOR} />
   ) : (
-    <Alerts entity={entity} />
+    <Alerts entity={entity} opts={opts} />
   );
 };

--- a/src/components/DashboardsCard/DashboardsCard.tsx
+++ b/src/components/DashboardsCard/DashboardsCard.tsx
@@ -22,41 +22,80 @@ import { useApi } from '@backstage/core-plugin-api';
 import { grafanaApiRef } from '../../api';
 import { useAsync } from 'react-use';
 import { Alert } from '@material-ui/lab';
-import { Link, Tooltip } from '@material-ui/core'
+import { Link, Tooltip } from '@material-ui/core';
 import { Dashboard } from '../../types';
 import { GRAFANA_ANNOTATION_TAG_SELECTOR, isGrafanaAvailable, tagSelectorFromEntity } from '../grafanaData';
 
-export const DashboardsTable = ({ entity, dashboards, title }: { entity: Entity, dashboards: Dashboard[], title?: string }) => {
+export const DashboardsTable = ({
+  entity,
+  dashboards,
+  opts,
+}: {
+  entity: Entity;
+  dashboards: Dashboard[];
+  opts?: DashboardCardOpts;
+}) => {
   const columns: TableColumn<Dashboard>[] = [
     {
+      title: 'id',
+      field: 'title',
+      hidden: true,
+      searchable: true,
+      render: (row: Dashboard): string => row.title,
+    },
+    {
       title: 'Title',
-      render: (row: Dashboard) => <Link href={row.url} target="_blank" rel="noopener">{row.title}</Link>,
+      render: (row: Dashboard) => (
+        <Link href={row.url} target="_blank" rel="noopener">
+          {row.title}
+        </Link>
+      ),
     },
     {
       title: 'Folder',
-      render: (row: Dashboard) => <Link href={row.folderUrl} target="_blank" rel="noopener">{row.folderTitle}</Link>,
+      render: (row: Dashboard) => (
+        <Link href={row.folderUrl} target="_blank" rel="noopener">
+          {row.folderTitle}
+        </Link>
+      ),
     },
   ];
 
   const titleElm = (
     <Tooltip title={`Note: only dashboard with the "${tagSelectorFromEntity(entity)}" tag are displayed.`}>
-      <span>{title || 'Dashboards'}</span>
+      <span>{opts?.title || 'Dashboards'}</span>
     </Tooltip>
   );
 
   return (
     <Table
       title={titleElm}
-      options={{ paging: false, search: false, sorting: false, draggable: false, padding: 'dense' }}
+      options={{
+        paging: opts?.paged ?? false,
+        pageSize: opts?.pageSize ?? 5,
+        search: opts?.searchable ?? false,
+        emptyRowsWhenPaging: false,
+        sorting: false,
+        draggable: false,
+        padding: 'dense',
+      }}
       data={dashboards}
       columns={columns}
     />
   );
 };
 
-const Dashboards = ({ entity, title }: { entity: Entity, title?: string }) => {
+const Dashboards = ({
+  entity,
+  opts,
+}: {
+  entity: Entity;
+  opts?: DashboardCardOpts;
+}) => {
   const grafanaApi = useApi(grafanaApiRef);
-  const { value, loading, error } = useAsync(async () => await grafanaApi.dashboardsByTag(tagSelectorFromEntity(entity)));
+  const { value, loading, error } = useAsync(
+    async () => await grafanaApi.dashboardsByTag(tagSelectorFromEntity(entity)),
+  );
 
   if (loading) {
     return <Progress />;
@@ -65,16 +104,23 @@ const Dashboards = ({ entity, title }: { entity: Entity, title?: string }) => {
   }
 
   return (
-    <DashboardsTable entity={entity} dashboards={value || []} title={title} />
+    <DashboardsTable entity={entity} dashboards={value || []} opts={opts} />
   );
 };
 
-export const DashboardsCard = ({ title }: { title?: string }) => {
+export type DashboardCardOpts = {
+  paged?: boolean;
+  searchable?: boolean;
+  pageSize?: number;
+  title?: string;
+};
+
+export const DashboardsCard = (opts?: DashboardCardOpts) => {
   const { entity } = useEntity();
 
   return !isGrafanaAvailable(entity) ? (
     <MissingAnnotationEmptyState annotation={GRAFANA_ANNOTATION_TAG_SELECTOR} />
   ) : (
-    <Dashboards entity={entity} title={title} />
+    <Dashboards entity={entity} opts={opts} />
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@
  */
 
 export interface Dashboard {
+  id: number;
   title: string;
   url: string;
   folderTitle: string;


### PR DESCRIPTION
These are the 2 MR in one, I didn't want to create 2 PR for it.

I will create a new one in a while to update the package.json and use `spreadshirt` instead of `k-phoen`. And maybe we need to add an action to publish to npm, but as soon as we have access to it