### PR TITLE
Make internal

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/node": "^14.14.32",
     "cross-fetch": "^3.1.5",
     "react": "^16.13.1 || ^17.0.0",
-    "react-dom": "^16.13.1"
+    "react-dom": "^17.0.2"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@spreadshirt/backstage-plugin-grafana",
+  "name": "@internal/backstage-plugin-grafana",
   "version": "0.1.12",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
Make `main` branch work for internal use again

- package is made `@internal` so Backstage compiles it
- `react-dom` was updated to `17.0.2` to use the same version as the rest of Backstage

For anyone else reading, we are using this temporary fork as a `git submodule` until our upstream MRs are merged.