### PR TITLE
Work around jest not supporting tests in git submodules

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,5 +63,9 @@
     "dist",
     "config.d.ts"
   ],
+  "jest": {
+    "//": "FIXME; to make backstage skip testing this (errors out when used as git submodule)",
+    "roots": []
+  },
   "configSchema": "config.d.ts"
 }


### PR DESCRIPTION
When we use this plugin as a git submodule in `plugins/grafana` in our
Backstage install it fails with the following error:

    Determining test suites to run...

      ● Test suite failed to run

        fatal: ../../packages/app/src: '../../packages/app/src' is outside repository at '/home/luna/projects/backstage/plugins/grafana'

    error Command failed with exit code 1.

This comes from a call to `git ls-files` in [1], which can't seem to get
avoided other than using this weird `roots: []` hack here.

So we do this to make our tests in Backstage work again until hopefully
our PRs get merged.

[1]: https://github.com/facebook/jest/blob/main/packages/jest-changed-files/src/git.ts#L64