### PR TITLE
Revert "Work around jest not supporting tests in git submodules"

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,9 +63,5 @@
     "dist",
     "config.d.ts"
   ],
-  "jest": {
-    "//": "FIXME; to make backstage skip testing this (errors out when used as git submodule)",
-    "roots": []
-  },
   "configSchema": "config.d.ts"
 }


### PR DESCRIPTION
Revert again because it broke the full test run.  We'll use
`--no-watch` instead.

This reverts commit 9de26a202d53d4abaecbf3c2c5fe3e2370047d09.