### PR TITLE
Bump versions to align to upgrade-helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
-    "react": "^16.13.1 || ^17.0.0",
+    "react": "^16.13.1 || ^17.0.2",
     "react-dom": "^16.13.1 || ^17.0.2",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
@@ -54,9 +54,9 @@
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^14.0.0",
-    "@types/node": "^14.14.32",
+    "@types/node": "^16.11.26",
     "cross-fetch": "^3.1.5",
-    "react": "^16.13.1 || ^17.0.0",
+    "react": "^16.13.1 || ^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.3.0"
   },


### PR DESCRIPTION
Aligning some deps to the latest upgrade-helper.

Anyways, this is still not reducing our yarn.lock file