### PR TITLE
Fix react-router imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.2",
-    "react-dom": "^16.13.1 || ^17.0.2"
+    "react-router": "6.0.0-beta.0 || ^6.3.0",
+    "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.22.5",
@@ -55,11 +56,7 @@
     "@testing-library/user-event": "^14.0.0",
     "@types/jest": "^29.0.0",
     "@types/node": "^16.11.26",
-    "cross-fetch": "^3.1.5",
-    "react": "^16.13.1 || ^17.0.2",
-    "react-dom": "^16.13.1",
-    "react-router": "^6.3.0",
-    "react-router-dom": "^6.3.0"
+    "cross-fetch": "^3.1.5"
   },
   "files": [
     "dist",


### PR DESCRIPTION
This was causing our backstage instance to be crashing due to routing issues.

I guess this was our previous setup, but when I brought all the upstream changes, it might have been lost.

This way of importing is the same we use for the releases, for example