### PR TITLE
Add alerts state

### DIFF
--- a/src/components/AlertsCard/AlertsCard.tsx
+++ b/src/components/AlertsCard/AlertsCard.tsx
@@ -30,16 +30,21 @@ const AlertStatusBadge = ({ alert }: { alert: GrafanaAlert }) => {
 
   switch (alert.state) {
     case "ok":
+    case "Normal":
       statusElmt = <StatusOK />;
       break;
     case "paused":
+    case "Pending":
       statusElmt = <StatusPending />;
       break;
     case "no_data":
     case "pending":
+    case 'NoData':
       statusElmt = <StatusWarning />;
       break;
     case "alerting":
+    case 'Alerting':
+    case 'Error':
       statusElmt = <StatusError />;
       break;
     default:
@@ -125,7 +130,7 @@ export const AlertsCard = (opts?: AlertsCardOpts) => {
     return <MissingAnnotationEmptyState annotation={GRAFANA_ANNOTATION_ALERT_LABEL_SELECTOR} />;
   }
 
-  const finalOpts = {...opts, ...{showState: opts?.showState && !unifiedAlertingEnabled}};
+  const finalOpts = {...opts, ...{showState: opts?.showState}};
 
   return <Alerts entity={entity} opts={finalOpts} />;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,3 +34,4 @@ export {
   GRAFANA_ANNOTATION_OVERVIEW_DASHBOARD,
 } from "./components/grafanaData";
 export type { Dashboard, Alert } from "./types";
+export { grafanaApiRef } from './api';

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,4 +33,4 @@ export {
   GRAFANA_ANNOTATION_TAG_SELECTOR,
   GRAFANA_ANNOTATION_OVERVIEW_DASHBOARD,
 } from "./components/grafanaData";
-export type { Dashboard } from "./types";
+export type { Dashboard, Alert } from "./types";


### PR DESCRIPTION
Needed an aggregation method, to not fetch the first occurrence but the most restrictive one. What does this mean? If there are 3 alert rules, and one is firing, the overall state should be firing as well, even if the other 2 are normal.

This also required to change a bit one of the methods, to allow using an array of selectors instead of only one. I will also try to send a MR to the guy upstream, because this would be nice to have it available there. I don't want to ahve many custom features when they are interesting to others as well.

This is based on the work done here: https://github.com/K-Phoen/backstage-plugin-grafana/pull/54