### PR TITLE
Return the Matching Selector of an Alert

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -188,6 +188,7 @@ export class GrafanaApiClient implements GrafanaApi {
       {
         name: alert.name,
         state: alert.state,
+        matchingSelector: "",
         url: `${this.domain}${alert.url}?panelId=${alert.panelId}&fullscreen&refresh=30s`,
       }
     ));
@@ -267,6 +268,7 @@ export class UnifiedAlertingGrafanaApiClient implements GrafanaApi {
         return {
           name: rule.grafana_alert.title,
           url: `${this.domain}/alerting/grafana/${rule.grafana_alert.uid}/view`,
+          matchingSelector: selector,
           state: this.getState(aggregatedAlertStates, matchingAlertInstances.length),
         };
       })

--- a/src/api.ts
+++ b/src/api.ts
@@ -188,7 +188,7 @@ export class GrafanaApiClient implements GrafanaApi {
       {
         name: alert.name,
         state: alert.state,
-        matchingSelector: "",
+        matchingSelector: dashboardTag,
         url: `${this.domain}${alert.url}?panelId=${alert.panelId}&fullscreen&refresh=30s`,
       }
     ));

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,5 +25,6 @@ export interface Dashboard {
 export interface Alert {
   name: string;
   state: string;
+  matchingSelector: string;
   url: string;
 }


### PR DESCRIPTION
This enables one to trace back, why an alert is part of the response.